### PR TITLE
Adds a file cache.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+.require-from-drive*

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "current file",
+            "program": "${file}"
+        }
+    ]
+}

--- a/readme.md
+++ b/readme.md
@@ -26,9 +26,15 @@ Then do this!
 
 ```js
 const requireFromDrive = require('require-from-drive').requireFromDrive
-const myModule = requireFromDrive('path/to/project/module.js')
-const config = requireFromDrive('path/to/project/config.json')
+const myModule = requireFromDrive({ path: 'path/to/project/module.js' })
+const config = requireFromDrive({ path: 'path/to/project/config.json' })
 ```
+
+A memory cache and a file cache are enabled by default. The file cache uses file names prefixed with `.require-from-drive`.
+
+The memory cache can be disabled by setting the `cache` option to `false`. The file cache can be disabled by setting the `cacheInFile` option to `false`.
+
+**IMPORTANT: Because there's a file cache, you should add `.require-from-drive*` to your `.gitignore`**
 
 ### Test
 

--- a/require_from_drive.d.ts
+++ b/require_from_drive.d.ts
@@ -1,1 +1,9 @@
-export function requireFromDrive(path: string, cache?: boolean): { [key: string]: any }
+export function requireFromDrive({
+  path,
+  cache,
+  cacheInFile,
+}: {
+  path: string,
+  cache?: boolean,
+  cacheInFile?: boolean,
+}): { [key: string]: any }

--- a/require_from_drive.js
+++ b/require_from_drive.js
@@ -1,11 +1,19 @@
 const request = require('sync-request')
 const requireFromString = require('require-from-string')
+const fs = require('fs')
 
 const addressVariableName = 'REQUIRE_FROM_DRIVE_SERVER_ADDRESS'
 const tokenVariableName = 'REQUIRE_FROM_DRIVE_SERVER_TOKEN'
 const address = process.env[addressVariableName]
 const token = process.env[tokenVariableName]
 const requestCache = new Map()
+const fileCachePrefix = '.require-from-drive'
+const maximumFileCacheAgeMilliseconds = 3600e3
+const debugLog = (...messages) => {
+  if (process.env.DEBUG === 'true') {
+    console.log('[require-from-drive debug]:', ...messages)
+  }
+}
 
 if (!address) {
   throw new Error(`Set the ${addressVariableName} environment variable`)
@@ -19,18 +27,75 @@ module.exports = {
   requireFromDrive
 }
 
-function requireFromDrive (path, cache = true) {
-  let response = cache ? requestWithCache(path) : requestWithoutCache(path)
+function requireFromDrive ({
+  path,
+  cache = true,
+  cacheInFile = true,
+}) {
+  let responseFromFileCache
+
+  debugLog(path, 'starting load process')
+
+  if (cacheInFile) {
+    responseFromFileCache = loadFromCacheFile(path)
+    debugLog(path, 'retrieved from file cache', responseFromFileCache)
+  }
+
+  const response = responseFromFileCache || (cache ? requestWithCache(path) : requestWithoutCache(path))
+
+  if (cacheInFile && !responseFromFileCache) {
+    debugLog(path, 'caching response in file')
+    fs.writeFileSync(getCacheFileName(path), response)
+  }
 
   try {
+    debugLog(path, 'attempting to parse as JSON')
+
     return JSON.parse(response)
   } catch (error) {
+    debugLog(path, 'failed to parse as JSON... falling back to parsing as a module')
+
     return requireFromString(response, path)
   }
 }
 
+function loadFromCacheFile (path) {
+  const fileName = getCacheFileName(path)
+
+  try {
+    const { mtime: lastModifiedTime } = fs.statSync(fileName)
+    const ageMilliseconds = Date.now() - lastModifiedTime.getTime()
+
+    debugLog(fileName, `found cache file with age ${ageMilliseconds} milliseconds`)
+
+    if (Date.now() - lastModifiedTime.getTime() > maximumFileCacheAgeMilliseconds) {
+      debugLog(fileName, `cache file is too old... ignoring it`)
+
+      return null
+    }
+  } catch(error) {
+    if (!error.message.includes('ENOENT')) {
+      throw error
+    }
+
+    debugLog(fileName, 'no cache file exists')
+
+    return null  // the file doesn't exist
+  }
+
+  debugLog(fileName, `reading cache file`)
+
+  return fs.readFileSync(fileName, 'utf-8')
+}
+
+function getCacheFileName(path) {
+  return fileCachePrefix + encodeURIComponent(path)
+}
+
 function requestWithCache (path) {
   if (!requestCache.has(path)) {
+    debugLog(path, 'using in-memory cache')
+
     requestCache.set(path, requestWithoutCache(path))
   }
 
@@ -38,12 +103,17 @@ function requestWithCache (path) {
 }
 
 function requestWithoutCache (path) {
+  debugLog(path, 'retrieving from Drive')
+
+  const startTime = Date.now()
   let response = request('GET', address, {
     qs: {
       path,
       token
     }
   }).getBody('utf-8')
+
+  debugLog(path, `retrieved from Drive in ${Date.now() - startTime} milliseconds`)
 
   if (/^Error: /.test(response)) {
     throw new Error(response)

--- a/test.js
+++ b/test.js
@@ -9,9 +9,9 @@ const testValue = {
   hi: 'there'
 }
 
-function requireTestFile (cache = true) {
+function requireTestFile ({ cache, cacheInFile } = {}) {
   try {
-    return requireFromDrive(testPath, cache)
+    return requireFromDrive({ path: testPath, cache, cacheInFile })
   } catch (error) {
     console.log(`This test requires the file ${testPath} to exist in the secret server folder in Google Drive and to contain ${JSON.stringify(testValue)}. If it doesn't exist, this test will fail. Set it up if necessary.`)
 
@@ -27,7 +27,7 @@ test('can retrieve secrets from Google Drive', () => {
 })
 
 test('throws for files that do not exist', () => {
-  assert.throws(() => requireFromDrive(Math.random().toString()))
+  assert.throws(() => requireFromDrive({ path: Math.random().toString() }))
 })
 
 test('caches results so that the second retrieval is fast', () => {
@@ -40,12 +40,22 @@ test('caches results so that the second retrieval is fast', () => {
   assert.ok(Date.now() - startTime <= 1)
 })
 
-test('can retrieve results without using the cache', () => {
+test('caches results in a file so that the second retrieval is fast even if the memory cache is not used', () => {
   requireTestFile()
 
   const startTime = Date.now()
 
-  requireTestFile(false)
+  requireTestFile({ cache: false })
+
+  assert.ok(Date.now() - startTime <= 10)
+})
+
+test('can retrieve results without using a cache', () => {
+  requireTestFile()
+
+  const startTime = Date.now()
+
+  requireTestFile({ cache: false, cacheInFile: false })
 
   assert.ok(Date.now() - startTime > 100)
 })


### PR DESCRIPTION
Closes #3.

This still needs work:
- [x] The memory cache should be checked and used before the file cache, since it's a lot faster.
- [x] the README should be updated to describe the new option, and explain that the cache files should be added to `.gitignore`.
- [x] double-check that `.d.ts` files have been updated appropriately.

This will be a major version bump because positional arguments were changed to a single object argument.